### PR TITLE
Avoid displaying journal on command line load by not refreshing it.

### DIFF
--- a/diffpy/pdfgui/gui/mainframe.py
+++ b/diffpy/pdfgui/gui/mainframe.py
@@ -225,7 +225,6 @@ class MainFrame(wx.Frame):
             self.workpath = os.path.dirname(fullpath)
             self.fileHistory.AddFileToHistory(fullpath)
             self.plotPanel.refresh()
-            self.journalPanel.refresh()
         return
 
     def __defineLocalIds(self):


### PR DESCRIPTION
This fixes a bug on OSX, wx2.9 where the journal is always shown on command line load.
