### PR TITLE
Only focus on journal when initially shown.

### DIFF
--- a/diffpy/pdfgui/gui/journalpanel.py
+++ b/diffpy/pdfgui/gui/journalpanel.py
@@ -79,7 +79,7 @@ class JournalPanel(wx.Panel, PDFPanel):
         dir, filename = os.path.split(self.fullpath)
         if not dir: dir = self.mainFrame.workpath
         d = wx.FileDialog(None, "Export to...",
-                dir, filename, matchstring, 
+                dir, filename, matchstring,
                 wx.SAVE|wx.OVERWRITE_PROMPT)
 
         if d.ShowModal() == wx.ID_OK:
@@ -116,7 +116,6 @@ class JournalPanel(wx.Panel, PDFPanel):
         if text != self.mainFrame.control.journal:
             self.textCtrlJournal.ChangeValue(self.mainFrame.control.journal)
             self.textCtrlJournal.SetInsertionPointEnd()
-        self.textCtrlJournal.SetFocus()
         pos = self.textCtrlJournal.GetInsertionPoint()
         self.textCtrlJournal.ShowPosition(pos)
         return

--- a/diffpy/pdfgui/gui/mainframe.py
+++ b/diffpy/pdfgui/gui/mainframe.py
@@ -1962,6 +1962,7 @@ class MainFrame(wx.Frame):
         else:
             self.auiManager.GetPane("journalPanel").Show()
             self.journalPanel.refresh()
+            self.journalPanel.SetFocus()
         self.auiManager.Update()
         return
 


### PR DESCRIPTION
This works around various journal display issues on OSX, wx2.9. The behavior this changes, focus on the journal whenever its text is refreshed, is arguably a bug on other platforms as well.
