### PR TITLE
fix open project ddp file on mac OS

### DIFF
--- a/src/diffpy/pdfgui/gui/mainframe.py
+++ b/src/diffpy/pdfgui/gui/mainframe.py
@@ -2126,7 +2126,7 @@ class MainFrame(wx.Frame):
             dir, filename = os.path.split(self.fullpath)
             if not dir:
                 dir = self.workpath
-            matchstring = "PDFgui project files (*.ddp)|*.ddp|All Files|*"
+            matchstring = "PDFgui project files (*.ddp)|*.ddp"
             d = wx.FileDialog(None, "Choose a file", dir
                     , "", matchstring, wx.OPEN)
             if d.ShowModal() == wx.ID_OK:


### PR DESCRIPTION
Hi Pavol,

I change the matchstring. Now in Mac OS, when open project files, people can only choose .ddp files.