### PR TITLE
MAINT: fix background color of parameter boxes

### DIFF
--- a/src/diffpy/pdfgui/gui/phaseconfigurepanel.py
+++ b/src/diffpy/pdfgui/gui/phaseconfigurepanel.py
@@ -266,7 +266,8 @@ class PhaseConfigurePanel(wx.Panel, PDFPanel):
                 tt.SetTip(self.constraints[var].formula)
             else:
                 textCtrl.SetEditable(True)
-                textCtrl.SetBackgroundColour(txtbg)
+                #textCtrl.SetBackgroundColour(txtbg)
+                textCtrl.SetBackgroundColour(wx.WHITE)
 
         # Now the grid
         rows = self.gridAtoms.GetNumberRows()


### PR DESCRIPTION
In py3 wxpython, background color is not white even if no constrains applied.

This PR closes #45 