### PR TITLE
REV: revert pickle protocol back to the highest one.

### DIFF
--- a/src/diffpy/pdfgui/utils.py
+++ b/src/diffpy/pdfgui/utils.py
@@ -23,8 +23,8 @@ import six
 from six.moves.configparser import RawConfigParser
 import six.moves.cPickle as pickle
 
-# keep project files compatible with Python 2
-PDFGUI_PICKLE_PROTOCOL = 2
+# protocol=2 keep project files compatible with Python 2
+# PDFGUI_PICKLE_PROTOCOL = 2
 
 
 def numericStringSort(lst):
@@ -59,7 +59,7 @@ def pickle_loads(sdata, encoding="latin1"):
 
 def safeCPickleDumps(obj):
     """Get pickle representation of an object possibly containing NaN or Inf.
-    By default it uses PDFGUI_PICKLE_PROTOCOL, but falls back to ASCII
+    By default it uses pickle.HIGHEST_PROTOCOL, but falls back to ASCII
     protocol 0 if there is SystemError frexp() exception.
 
     obj -- object to be pickled
@@ -68,7 +68,7 @@ def safeCPickleDumps(obj):
     """
     ascii_protocol = 0
     try:
-        s = pickle.dumps(obj, PDFGUI_PICKLE_PROTOCOL)
+        s = pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
     except SystemError:
         s = pickle.dumps(obj, ascii_protocol)
     return s


### PR DESCRIPTION
This reverts the commit a0c745e48b86eda144212e977372dd4673fae4d3 work. The pickle will be saved in the highest protocol available in the python3 version.