### PR TITLE
Use `matplotlib` instead of `matplotlib-base` in `run.txt`

### DIFF
--- a/news/matplotlib.rst
+++ b/news/matplotlib.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* use matplotlib isntead of matplotlib-base in run.txt for pip install
+
+**Security:**
+
+* <news item>

--- a/news/matplotlib.rst
+++ b/news/matplotlib.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* use matplotlib isntead of matplotlib-base in run.txt for pip install
+* use matplotlib instead of matplotlib-base in run.txt for pip install
 
 **Security:**
 

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -3,4 +3,4 @@ wxpython
 diffpy.pdffit2
 diffpy.structure
 diffpy.utils
-matplotlib-base
+matplotlib


### PR DESCRIPTION
The latest rc version of pdfgui contains `run.txt` which contains `matplotlib-base`. 

This PR fixes the following: 

```
pip install diffpy.pdfgui==3.1.0rc5

ERROR: Could not find a version that satisfies the requirement matplotlib-base (from diffpy-pdfgui) (from versions: none)
ERROR: No matching distribution found for matplotlib-base
```

Closes #207 - tested that run.txt dependencies are installed during pip install.