### PR TITLE
Add pip.txt, pyproject builds from pip.txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ exclude = []  # exclude packages matching these glob patterns (empty by default)
 namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 
 [tool.setuptools.dynamic]
-dependencies = {file = ["requirements/run.txt"]}
+dependencies = {file = ["requirements/pip.txt"]}
 
 [tool.black]
 line-length = 115

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,0 +1,6 @@
+numpy
+wxpython
+diffpy.pdffit2
+diffpy.structure
+diffpy.utils
+matplotlib


### PR DESCRIPTION
Try running `pip install -e .` without this fix...

See https://github.com/diffpy/diffpy.pdfmorph/pull/132