### PR TITLE
replace danse links (without documentations)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,9 +4,10 @@ Authors
 DiffPy was initiated as part of the Distributed Data Analysis of Neutron
 Scattering Experiments (DANSE) project, funded by the National Science
 Foundation under grant DMR-0520547.  More information on DANSE can be
-found at http://danse.us.  Any opinions, findings, and conclusions or
-recommendations expressed in this material are those of the author(s)
-and do not necessarily reflect the views of the NSF.
+found at `DANSE Project Legacy Page <https://www.its.caltech.edu/~matsci/btf/DANSE_web_page.html>`_.
+Any opinions, findings, and conclusions or recommendations expressed
+in this material are those of the author(s) and do not necessarily reflect
+the views of the NSF.
 
 Main Contributors
 -----------------

--- a/news/danselink.rst
+++ b/news/danselink.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* no news: small changes to links
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/pdfgui/gui/aboutdialog.py
+++ b/src/diffpy/pdfgui/gui/aboutdialog.py
@@ -221,7 +221,7 @@ class DialogAbout(wx.Dialog):
         event.Skip()
 
     def onDanseLogo(self, event):  # wxGlade: DialogAbout.<event_handler>
-        launchBrowser("http://danse.us")
+        launchBrowser("https://www.its.caltech.edu/~matsci/btf/DANSE_web_page.html")
         event.Skip()
 
     def onMsuLogo(self, event):  # wxGlade: DialogAbout.<event_handler>

--- a/tests/test_aboutdialog.py
+++ b/tests/test_aboutdialog.py
@@ -53,7 +53,7 @@ class TestDialogAbout(GUITestCase):
             self._clickbutton(d.bitmap_button_nsf)
             self.assertTrue(self.url.endswith("www.nsf.gov"))
             self._clickbutton(d.bitmap_button_danse)
-            self.assertTrue(self.url.endswith("danse.us"))
+            self.assertTrue(self.url.endswith("www.its.caltech.edu/~matsci/btf/DANSE_web_page.html"))
             self._clickbutton(d.bitmap_button_msu)
             self.assertTrue(self.url.endswith("www.msu.edu"))
             self._clickbutton(d.bitmap_button_columbia)


### PR DESCRIPTION
This PR is for replacing the danse links (not including the links related to documentations). Those will be included in a later PR. Together will closes the two previous PRs (#202 and #203 )

@sbillinge As for the documentation links, it seems like some of them were not deployed (even though we have run the deploy workflows). This can be checked under the Action tab Management field. The good ones (like [structure](https://github.com/diffpy/diffpy.structure/actions)) has the `Deployment` link and GitHub-pages bot ran. But for packages like pdfgui, pdffit2, cookiecutter they don't have the api/documentation pages release. 

I think there are configurations needed to be changed in the repo settings-Code and automation-Pages