### PR TITLE
fix failing CI tests

### DIFF
--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install diffpy.pdfgui and requirements
         run: |
           conda install --file requirements/test.txt
-          conda install wxpython diffpy.utils matplotlib-base
+          conda install wxpython diffpy.utils matplotlib-base gsl
           pip install diffpy.pdffit2==1.4.4rc4
           python -m pip install . --no-deps
 

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           conda install --file requirements/test.txt
           conda install wxpython diffpy.utils matplotlib-base
-          pip install diffpy.pdffit2==1.4.4rc6
+          pip install diffpy.pdffit2==1.4.4rc4
           python -m pip install . --no-deps
 
       - name: Start Xvfb

--- a/news/ci.rst
+++ b/news/ci.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* no news: modification on CI workflow
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
closes #238 

@sbillinge @bobleesj The failing CI was caused by problematic distribution of `pdffit2` on pypi, namely the `1.4.4rc6` version. The problem is very likely caused by the wheel built by CI for windows not functional, even if the wheels had been tested locally. Let me research more 

As for the test here, let's use `1.4.4rc4` for now, which build the wheel on the fly with gsl.