### PR TITLE
fix: buggy test click button url

### DIFF
--- a/news/fixwin.rst
+++ b/news/fixwin.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* no news: fix the buggy test
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -35,20 +35,17 @@ def overridewebbrowser(fnc_open):
     "Temporarily replace `webbrowser.open` with given function."
     import webbrowser
 
-    controller = webbrowser.get()
-    save_open = controller.open
+    save_open = webbrowser.open
 
     def open_override(url, new=0, autoraise=True):
         fnc_open(url)
         return True
 
-    controller.open = open_override
+    webbrowser.open = open_override
     try:
-        yield save_open
+        yield
     finally:
-        del controller.open
-        assert controller.open == save_open
-    pass
+        webbrowser.open = save_open
 
 
 @contextmanager


### PR DESCRIPTION
@sbillinge please check, thanks

This is not a fix on the actual code. This is for fixing a buggy test code (bug on test code not on the actual code) that fails all the windows matrix test.

The problem is on `test_LogoClicks` in `test_aboutdialog.py`. This test is to simulate user interactions with the `About` tag in GUI and verify clicking on various logo buttons leads to the expected url. The modified context manager `overridewebbrowser` is in testutils but used in `test_LogoClicks`. It try to temporarily replaces the normal behavior of opening a web browser by calling `set_url` which captures the url that `pdfgui` tries to open without actually opening the browser.

The reason why the test was not passing only on Windows is because `webbrowser.open` work differently on windows, which returns *different* instance for subsequent calls. Thus the override in the old test code doesn't stick to the right instance as the code that actually calls `webbrowser.open` ends up using a different unchanged `controller`.


