### PR TITLE
ci: fix failing py3.13 on osx-64

### DIFF
--- a/.github/workflows/matrix-and-codecov-on-merge-to-main.yml
+++ b/.github/workflows/matrix-and-codecov-on-merge-to-main.yml
@@ -32,7 +32,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: test
-          auto-update-conda: true
+          miniforge-version: latest
           environment-file: environment.yml
           auto-activate-base: false
           python-version: ${{ matrix.python-version }}
@@ -44,9 +44,6 @@ jobs:
 
       - name: Install diffpy.pdfgui and requirements
         run: |
-          if [[ "${{ matrix.os }}" == "macos-13" ]]; then
-            export CONDA_OVERRIDE_OSX=11.0 # Override virtual package detection for osx-64
-          fi
           conda install --file requirements/test.txt
           conda install wxpython diffpy.utils matplotlib-base
           pip install diffpy.pdffit2==1.5.0rc1

--- a/.github/workflows/matrix-and-codecov-on-merge-to-main.yml
+++ b/.github/workflows/matrix-and-codecov-on-merge-to-main.yml
@@ -44,6 +44,9 @@ jobs:
 
       - name: Install diffpy.pdfgui and requirements
         run: |
+          if [[ "${{ matrix.os }}" == "macos-13" ]]; then
+            export CONDA_OVERRIDE_OSX=11.0 # Override virtual package detection for osx-64
+          fi
           conda install --file requirements/test.txt
           conda install wxpython diffpy.utils matplotlib-base
           pip install diffpy.pdffit2==1.5.0rc1

--- a/news/osx13.rst
+++ b/news/osx13.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* no news: modification on CI workflow
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/osx13.rst
+++ b/news/osx13.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* no news: modification on CI workflow
+* <news item>
 
 **Changed:**
 
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* <news item>
+* Use miniforge in CI to avoid strange error of incorrect MacOS version logged from base     env
 
 **Security:**
 


### PR DESCRIPTION
@sbillinge please check, thanks

`wxpython 4.2.2` support py3.13 for osx-64, but it can only be installed with OSX version >=11.0 (Big Sur). Seems like `set-up miniconda` detect OSX version of GitHub runner to be 10.16, here we mock it to be 11.0 in order to resolve `wxpython`.