### PR TITLE
fix: fix TypeError when using Nyquist interp

### DIFF
--- a/news/interp_xtype.rst
+++ b/news/interp_xtype.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed TypeError when using Nyquist interp.
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/pdfgui/control/fitdataset.py
+++ b/src/diffpy/pdfgui/control/fitdataset.py
@@ -848,6 +848,9 @@ def grid_interpolation(x0, y0, x1, left=None, right=None, tp=None):
     Otherwise it uses the internal :func:`_linear_interpolation` routine.
     """
     if tp == "Nyquist":
+        x0 = numpy.asarray(x0)
+        x1 = numpy.asarray(x1)
+        y0 = numpy.asarray(y0)
         return wsinterp(x1, x0, y0, left, right)
     else:
         left = 0.0 if left is None else left


### PR DESCRIPTION
@sbillinge please check, thanks

Previously when using nyquest grid it will give error like
```
TypeError: '<' not supported between instances of 'list' and 'float'
```
which is because the sampler function in `diffpy.utils` only accept `ndarray` while `pdfgui` provide array_like (list) type