### PR TITLE
docs: remove diffpy.structure and numpy in readme.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Activate the environment: ::
 It is necessary to get versions of pdffit2 built for Mac from Python package index (Pypi).  To install
 pdffit2 from Pypi using ``pip`` to download and install the latest version from `Python Package Index <https://pypi.python.org>`_: ::
 
-        conda install wxpython diffpy.utils diffpy.structure matplotlib-base pycifrw numpy
+        conda install wxpython diffpy.utils matplotlib-base pycifrw
         pip install diffpy.pdffit2
 
 Now we want to install PDFgui from conda-forge: ::

--- a/news/fix-installation.rst
+++ b/news/fix-installation.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Remove diffpy.structure and numpy in macOS Arm64 readme installation since they are installed by other conda-forge dependencies.
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Remove them in readme for macOS arm64  installation. `diffpy.pdffit2` installs `diffpy.structure` and `numpy` is eveywhere.