### PR TITLE
fix:hot-fix pdfgui functionality fix after skpkg

### DIFF
--- a/.github/workflows/matrix-and-codecov.yml
+++ b/.github/workflows/matrix-and-codecov.yml
@@ -16,6 +16,6 @@ jobs:
     with:
       project: diffpy.pdfgui
       c_extension: false
-      headless: false
+      headless: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -10,6 +10,6 @@ jobs:
     with:
       project: diffpy.pdfgui
       c_extension: false
-      headless: false
+      headless: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/news/fix-gui-functionality.rst
+++ b/news/fix-gui-functionality.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Fixed linked the fits with string input
+* Fixed linked fits with string input
 
 **Security:**
 

--- a/news/fix-gui-functionality.rst
+++ b/news/fix-gui-functionality.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No News Added: hot-fix on gui-functionality
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/fix-gui-functionality.rst
+++ b/news/fix-gui-functionality.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* <news item>
+* No News Added: fix gui functionality after skpkg
 
 **Changed:**
 
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Fixed linked fits with string input
+* <news item>
 
 **Security:**
 

--- a/news/fix-gui-functionality.rst
+++ b/news/fix-gui-functionality.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* No News Added: hot-fix on gui-functionality
+* <news item>
 
 **Changed:**
 
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* <news item>
+* Fixed linked the fits with string input
 
 **Security:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ exclude = []  # exclude packages matching these glob patterns (empty by default)
 namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 
 [project.scripts]
-diffpy-pdfgui = "diffpy.pdfgui.app:main"
+pdfgui = "diffpy.pdfgui.applications.pdfgui:main"
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements/pip.txt"]}

--- a/src/diffpy/pdfgui/gui/aboutdialog.py
+++ b/src/diffpy/pdfgui/gui/aboutdialog.py
@@ -16,12 +16,15 @@
 ##############################################################################
 
 import random
+from datetime import datetime, timezone
 
 import wx
 import wx.lib.agw.hyperlink
 
 from diffpy.pdfgui.gui.pdfguiglobals import iconpath
-from diffpy.pdfgui.version import __date__, __version__
+from diffpy.pdfgui.version import __version__
+
+__date__ = datetime.now(timezone.utc).date().isoformat()
 
 _acknowledgement = """\
 This software was developed by the Billinge-group as part of the Distributed

--- a/src/diffpy/pdfgui/gui/parameterspanel.py
+++ b/src/diffpy/pdfgui/gui/parameterspanel.py
@@ -250,7 +250,10 @@ class ParametersPanel(wx.Panel, PDFPanel):
             temp = self.parameters[key].initialValue()
             if temp != value:
                 self.parameters[key].setInitial(value)
-                self.grid_parameters.SetCellValue(row, 0, str(float(value)))
+                if value is int or value is float:
+                    self.grid_parameters.SetCellValue(row, 0, str(float(value)))
+                else:
+                    self.grid_parameters.SetCellValue(row, 0, value)
                 self.mainFrame.needsSave()
 
         elif col == 1:  # flag "fixed"

--- a/src/diffpy/pdfgui/gui/parameterspanel.py
+++ b/src/diffpy/pdfgui/gui/parameterspanel.py
@@ -250,10 +250,7 @@ class ParametersPanel(wx.Panel, PDFPanel):
             temp = self.parameters[key].initialValue()
             if temp != value:
                 self.parameters[key].setInitial(value)
-                if value is int or value is float:
-                    self.grid_parameters.SetCellValue(row, 0, str(float(value)))
-                else:
-                    self.grid_parameters.SetCellValue(row, 0, value)
+                self.grid_parameters.SetCellValue(row, 0, str(float(value)))
                 self.mainFrame.needsSave()
 
         elif col == 1:  # flag "fixed"

--- a/src/diffpy/pdfgui/gui/pdfguiglobals.py
+++ b/src/diffpy/pdfgui/gui/pdfguiglobals.py
@@ -14,8 +14,8 @@
 ##############################################################################
 """This module contains global parameters needed by PDFgui."""
 
-import os.path
 from importlib.resources import files
+from pathlib import Path
 
 from diffpy.pdfgui.gui import debugoptions
 
@@ -24,34 +24,24 @@ name = "PDFgui"
 # Maximum number of files to be remembered
 MAXMRU = 5
 # The location of the configuration file
-configfilename = os.path.expanduser("~/.pdfgui_py3.cfg")
+configfilename = Path.home() / ".pdfgui_py3.cfg"
 # Project modification flag
 isAltered = False
 
-# Resolve APPDATADIR base path to application data files.
-try:
-    _mydir = os.path.abspath(str(files(__name__)))
-except TypeError:  # For Python < 3.12
-    _mydir = os.path.abspath(os.path.dirname(__file__))
+_mydir = Path(str(files(__name__))).resolve()
 
-_upbasedir = os.path.normpath(_mydir + "/../../..")
-_development_mode = os.path.basename(_upbasedir) == "src" and os.path.isfile(
-    os.path.join(_upbasedir, "../pyproject.toml")
-)
+_upbasedir = _mydir.parents[2]
+_development_mode = _upbasedir.name == "src" and (_upbasedir.parent / "pyproject.toml").is_file()
 
 # Requirement must have egg-info.  Do not use in _development_mode.
 _req = "diffpy.pdfgui"
 
-# pavol
-# APPDATADIR = (os.path.dirname(_upbasedir) if _development_mode
-#               else str(files(_req)))
-# long
 if _development_mode:
-    APPDATADIR = os.path.dirname(_mydir)
+    APPDATADIR = _mydir.parent
 else:
-    APPDATADIR = str(files(_req))
+    APPDATADIR = Path(str(files(_req))).resolve()
 
-APPDATADIR = os.path.abspath(APPDATADIR)
+APPDATADIR = APPDATADIR.resolve()
 
 # Location of the HTML manual
 docMainFile = "https://diffpy.github.io/diffpy.pdfgui/manual.html"
@@ -62,16 +52,24 @@ del _req
 
 
 def iconpath(iconfilename):
-    """Full path to the icon file in pdfgui installation. This function
-    should be used whenever GUI needs access to custom icons.
+    """Full path to the icon file in pdfgui installation.
 
-    iconfilename -- icon file name without any path
+    This function should be used whenever GUI needs access to custom
+    icons.
 
-    Return string.
+    Parameters
+    ----------
+    iconfilename : str
+        The icon file name without any path.
+
+    Returns
+    -------
+    str
+        The full path to the icon file.
     """
-    rv = os.path.join(APPDATADIR, "icons", iconfilename)
-    assert os.path.isfile(rv), "icon file does not exist"
-    return rv
+    rv = APPDATADIR / "icons" / iconfilename
+    assert rv.is_file(), "icon file does not exist"
+    return str(rv)
 
 
 # options and arguments passed on command line
@@ -79,7 +77,6 @@ cmdopts = []
 cmdargs = []
 
 # debugging options:
-
 dbopts = debugoptions.DebugOptions()
 
 # End of file


### PR DESCRIPTION
We have done the skpkg for this without waiting for its dependency new version release and we merged that PR. But today when I ran it using the developer version of `diffpy.pdfgui`, it gives me a lot of errors other than the python version. So, I made this PR to fix all of these. 
1. I added an `__date__` variable in `aboutdialog.py` since it is the only place that we need the `__date__`. This helps us to run the `pytest` sucessfully.
2. Closes #194, and also I updated the `os.path` to `Path()` object to comply with the group standard. 
3. I also made an edit to the `pyproject.toml`, this is needed because in the `skpkg` it changes the actual script running the `pdfgui`. Therefore, I changed it back to the application and in order to comply with the name of the app in the tutorial, I also changed the name of the command from `diffpy-pdfgui` back to `pdfgui`. 

After finishing up these, I ran the `pytest` and also running the app, it works properly now. The CI would still failing since dependecies haven't updated to `3.14` yet, but now local test would confirm that everything is right now.
```
(diffpy.pdfgui_env) huarundong@Stevens-MacBook-Pro-405 diffpy.pdfgui % pytest
================================================================================================================== test session starts ===================================================================================================================
platform darwin -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/huarundong/dbs/diffpy.pdfgui
configfile: pyproject.toml
collected 58 items                                                                                                                                                                                                                                       

tests/test_aboutdialog.py .                                                                                                                                                                                                                        [  1%]
tests/test_calculation.py .                                                                                                                                                                                                                        [  3%]
tests/test_constraint.py ....                                                                                                                                                                                                                      [ 10%]
tests/test_datasetpanels.py ....                                                                                                                                                                                                                   [ 17%]
tests/test_dopingseriespanel.py .                                                                                                                                                                                                                  [ 18%]
tests/test_extendedplotframe.py ..                                                                                                                                                                                                                 [ 22%]
tests/test_fitdataset.py ..                                                                                                                                                                                                                        [ 25%]
tests/test_fitstructure.py ..........                                                                                                                                                                                                              [ 43%]
tests/test_insertrowsdialog.py .                                                                                                                                                                                                                   [ 44%]
tests/test_loadproject.py ......                                                                                                                                                                                                                   [ 55%]
tests/test_mainframe.py ..                                                                                                                                                                                                                         [ 58%]
tests/test_parameter.py ..                                                                                                                                                                                                                         [ 62%]
tests/test_parameterspanel.py ....                                                                                                                                                                                                                 [ 68%]
tests/test_pdfdataset.py ..                                                                                                                                                                                                                        [ 72%]
tests/test_pdfguicontrol.py .                                                                                                                                                                                                                      [ 74%]
tests/test_pdfstructure.py .....                                                                                                                                                                                                                   [ 82%]
tests/test_phaseconfigurepanel.py ..                                                                                                                                                                                                               [ 86%]
tests/test_structureviewer.py ......                                                                                                                                                                                                               [ 96%]
tests/test_temperatureseriespanel.py .                                                                                                                                                                                                             [ 98%]
tests/test_version.py .                                                                                                                                                                                                                            [100%]

==================================================================================================================== warnings summary ====================================================================================================================
tests/test_datasetpanels.py::TestDataSetPanel::test_onSampling
tests/test_loadproject.py::TestLoadProject::test___init__
tests/test_parameter.py::TestParameter::test___init__
tests/test_phaseconfigurepanel.py::TestPhaseConfigurePanel::test_onCellRightClick
  /Users/huarundong/dbs/diffpy.pdfgui/src/diffpy/pdfgui/control/fitdataset.py:480: VisibleDeprecationWarning: dtype(): align should be passed as Python or NumPy boolean but got `align=0`. Did you mean to pass a tuple to create a subarray type? (Deprecated NumPy 2.4)
    content = pickle.loads(z.read(subpath + "calc"), encoding="latin1")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================= 58 passed, 4 warnings in 1.22s =============================================================================================================
```
<img width="2035" height="1184" alt="Screenshot 2026-03-26 at 10 18 09 PM" src="https://github.com/user-attachments/assets/ff920d3f-5115-44b6-a816-bcf15762b7d2" />
<img width="599" height="398" alt="Screenshot 2026-03-26 at 10 19 49 PM" src="https://github.com/user-attachments/assets/51d34697-35d5-40f9-9dde-4c5f916b5868" />

