### PR TITLE
CODE: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ ci:
   submodules: false
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -21,45 +21,45 @@ repos:
       - id: check-toml
       - id: check-added-large-files
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 26.3.1
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.3.0
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 9.0.0a3
     hooks:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.7.1
+    rev: 0.9.1
     hooks:
       - id: nbstripout
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: no-commit-to-branch
         name: Prevent Commit to Main Branch
         args: ["--branch", "main"]
         stages: [pre-commit]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.2
     hooks:
       - id: codespell
         additional_dependencies:
           - tomli
   # prettier - multi formatter for .json, .yml, and .md files
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         additional_dependencies:
           - "prettier@^3.2.4"
   # docformatter - PEP 257 compliant docstring formatter
-  - repo: https://github.com/s-weigand/docformatter
-    rev: 5757c5190d95e5449f102ace83df92e7d3b06c6c
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.8
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]

--- a/news/precommit-hook-update.rst
+++ b/news/precommit-hook-update.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news needed: updating docformatter not user facing
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/__init__.py
+++ b/src/diffpy/__init__.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Blank namespace package for module diffpy."""
 
-
 from pkgutil import extend_path
 
 __path__ = extend_path(__path__, __name__)

--- a/src/diffpy/pdfgui/applications/pdfgui.py
+++ b/src/diffpy/pdfgui/applications/pdfgui.py
@@ -12,9 +12,8 @@
 # See LICENSE.txt for license information.
 #
 ##############################################################################
-"""
-PDFgui Graphical User Interface for Pair Distribution Function fitting
-Usage: pdfgui [project.dpp]
+"""PDFgui Graphical User Interface for Pair Distribution Function
+fitting Usage: pdfgui [project.dpp]
 
 PDFgui is graphical user interface to PDFfit2 - a Python library for PDF
 simulation and structure refinement.  PDFgui has many nice features such

--- a/src/diffpy/pdfgui/control/calculation.py
+++ b/src/diffpy/pdfgui/control/calculation.py
@@ -291,11 +291,12 @@ class Calculation(PDFComponent):
         return
 
     def copy(self, other=None):
-        """Copy self to other. if other is None, create new instance.
+        """Copy self to other.
 
-        other -- reference to other object
+        if other is None, create new instance.
+                other -- reference to other object
 
-        returns reference to copied object
+                returns reference to copied object
         """
         if other is None:
             other = Calculation(self.name)

--- a/src/diffpy/pdfgui/control/constraint.py
+++ b/src/diffpy/pdfgui/control/constraint.py
@@ -67,8 +67,9 @@ class Constraint:
         return result
 
     def lambdaFormula(self):
-        """Build lambda function from constraint formula. Lambda
-        function expects dictionary argument.
+        """Build lambda function from constraint formula.
+
+        Lambda function expects dictionary argument.
 
         returns lambda function
         """

--- a/src/diffpy/pdfgui/control/fitdataset.py
+++ b/src/diffpy/pdfgui/control/fitdataset.py
@@ -243,8 +243,9 @@ class FitDataSet(PDFDataSet):
         return self
 
     def write(self, filename):
-        """Same as writeCalc().  Use writeObs() to save experimental PDF
-        data.
+        """Same as writeCalc().
+
+        Use writeObs() to save experimental PDF data.
 
         filename -- name of file to write to
 
@@ -267,8 +268,9 @@ class FitDataSet(PDFDataSet):
         return
 
     def writeStr(self):
-        """Same as writeCalcStr.  Use writeObsStr() for experimental
-        PDF.
+        """Same as writeCalcStr.
+
+        Use writeObsStr() for experimental PDF.
 
         Return data string.
         """
@@ -379,9 +381,11 @@ class FitDataSet(PDFDataSet):
         return s
 
     def findParameters(self):
-        """Obtain dictionary of parameters used by self.constraints. The
-        keys of returned dictionary are integer parameter indices, and
-        their values Parameter instances, with guessed initial values.
+        """Obtain dictionary of parameters used by self.constraints.
+
+        The keys of returned dictionary are integer parameter indices,
+        and their values Parameter instances, with guessed initial
+        values.
 
         returns dictionary of indices and Parameter instances
         """
@@ -434,11 +438,12 @@ class FitDataSet(PDFDataSet):
         return
 
     def copy(self, other=None):
-        """Copy self to other. if other is None, create new instance.
+        """Copy self to other.
 
-        other -- ref to other object
+        if other is None, create new instance.
+                other -- ref to other object
 
-        returns reference to copied object
+                returns reference to copied object
         """
         # check arguments
         if other is None:
@@ -529,9 +534,10 @@ class FitDataSet(PDFDataSet):
     # interface for data sampling
 
     def getFitSamplingType(self):
-        """Description of r-sampling used in the fit.  This method
-        compares self.fitrstep with r-sampling in the observed data and
-        with Nyquist r step.
+        """Description of r-sampling used in the fit.
+
+        This method compares self.fitrstep with r-sampling in the
+        observed data and with Nyquist r step.
 
         Return a string, possible values are "data", "Nyquist" or
         "custom".
@@ -683,7 +689,8 @@ class FitDataSet(PDFDataSet):
         _get_rcalc,
         _set_rcalc,
         doc="""R-grid for refined data, read-only.
-        Use fitrmin, fitrmax, fitrstep to change it""",
+        Use fitrmin, fitrmax, fitrstep to change it"""
+                                                      ,
     )
 
     # Gcalc

--- a/src/diffpy/pdfgui/control/fitstructure.py
+++ b/src/diffpy/pdfgui/control/fitstructure.py
@@ -170,9 +170,11 @@ class FitStructure(PDFStructure):
         return
 
     def findParameters(self):
-        """Obtain dictionary of parameters used by self.constraints. The
-        keys of returned dictionary are integer parameter indices, and
-        the values are Parameter instances, with guessed initial values.
+        """Obtain dictionary of parameters used by self.constraints.
+
+        The keys of returned dictionary are integer parameter indices,
+        and the values are Parameter instances, with guessed initial
+        values.
 
         returns dictionary of indices and Parameter instances
         """
@@ -677,11 +679,13 @@ class FitStructure(PDFStructure):
         # delayed initialization of the class variable
         if self._rxatomselection is None:
             FitStructure._rxatomselection = re.compile(
-                r"""
-            (?P<negate>!?)                      # exclamation point
-            (?:(?P<element>[a-zA-Z]+)$|         # element|all   or
-               (?P<start>\d+)(?P<stop>:\d+)?$   # number range
-            )""",
+                r"""(?P<negate>!?)                      # exclamation
+                point (?:(?P<element>[a-zA-Z]+)$|         # element|all
+                or.
+
+                (?P<start>\d+)(?P<stop>:\d+)?$   # number range )
+                """
+                   ,
                 re.VERBOSE,
             )
         assert self._rxatomselection
@@ -724,11 +728,12 @@ class FitStructure(PDFStructure):
         return rv
 
     def copy(self, other=None):
-        """Copy self to other. if other is None, create new instance.
+        """Copy self to other.
 
-        other -- reference to other object
+        if other is None, create new instance.
+                other -- reference to other object
 
-        returns reference to copied object
+                returns reference to copied object
         """
         # check arguments
         if other is None:

--- a/src/diffpy/pdfgui/control/fitting.py
+++ b/src/diffpy/pdfgui/control/fitting.py
@@ -178,10 +178,11 @@ class Fitting(Organizer):
         return "f_" + self.name
 
     def copy(self, other=None):
-        """Copy self to other. if other is None, create an instance.
+        """Copy self to other.
 
-        other -- ref to other object
-        return value: reference to copied object
+        if other is None, create an instance.
+                other -- ref to other object
+                return value: reference to copied object
         """
         if other is None:
             other = Fitting(self.name)
@@ -448,8 +449,9 @@ class Fitting(Organizer):
         return
 
     def outputBondAngle(self, struc, i, j, k):
-        """Output bond angle defined by atoms i, j, k. The angle is
-        calculated using the shortest lengths ji and jk with respect to
+        """Output bond angle defined by atoms i, j, k.
+
+        The angle is calculated using the shortest lengths ji and jk with respect to
         periodic boundary conditions.
 
         struc   -- instance of PDFStructure
@@ -472,8 +474,9 @@ class Fitting(Organizer):
         return
 
     def outputBondLengthAtoms(self, struc, i, j):
-        """Output shortest bond between atoms i, j. Periodic boundary
-        conditions are applied to find the shortest bond.
+        """Output shortest bond between atoms i, j.
+
+        Periodic boundary conditions are applied to find the shortest bond.
 
         struc   -- instance of PDFStructure
         i, j    -- atom indices starting at 1

--- a/src/diffpy/pdfgui/control/organizer.py
+++ b/src/diffpy/pdfgui/control/organizer.py
@@ -30,8 +30,9 @@ def spd_constrained(ds):
 
 
 class Organizer(PDFComponent):
-    """Base class for Fitting. It holds separate lists of datasets,
-    strucs and calculations.
+    """Base class for Fitting.
+
+    It holds separate lists of datasets, strucs and calculations.
 
     datasets:     dataset list
     strucs:       structure list
@@ -204,10 +205,11 @@ class Organizer(PDFComponent):
         return
 
     def copy(self, other=None):
-        """Copy self to other. if other is None, create an instance.
+        """Copy self to other.
 
-        other -- ref to other object
-        returns reference to copied object
+        if other is None, create an instance.
+                other -- ref to other object
+                returns reference to copied object
         """
         if other is None:
             other = Organizer(self.name)

--- a/src/diffpy/pdfgui/control/pdfdataset.py
+++ b/src/diffpy/pdfgui/control/pdfdataset.py
@@ -99,8 +99,9 @@ class PDFDataSet(PDFComponent):
         return
 
     def setvar(self, var, value):
-        """Assign data member using PdfFit-style variable. Used by
-        applyParameters().
+        """Assign data member using PdfFit-style variable.
+
+        Used by applyParameters().
 
         var   -- string representation of dataset PdfFit variable.
                  Possible values: qdamp, qbroad, dscale
@@ -116,8 +117,9 @@ class PDFDataSet(PDFComponent):
         return
 
     def getvar(self, var):
-        """Obtain value corresponding to PdfFit dataset variable. Used
-        by findParameters().
+        """Obtain value corresponding to PdfFit dataset variable.
+
+        Used by findParameters().
 
         var   -- string representation of dataset PdfFit variable.
                  Possible values: qdamp, qbroad, dscale
@@ -334,10 +336,11 @@ class PDFDataSet(PDFComponent):
         return datastring
 
     def copy(self, other=None):
-        """Copy self to other. if other is None, create new instance.
+        """Copy self to other.
 
-        other -- ref to other object
-        returns reference to copied object
+        if other is None, create new instance.
+                other -- ref to other object
+                returns reference to copied object
         """
         if other is None:
             other = PDFDataSet(self.name)

--- a/src/diffpy/pdfgui/control/pdfguimacros.py
+++ b/src/diffpy/pdfgui/control/pdfguimacros.py
@@ -52,42 +52,30 @@ def makeRSeries(
 
     # MIN-MIN: FIRST < LAST
     if minfirst is not None and minlast is not None and not minfirst < minlast:
-        message = (
-            "The first value of the minimum (%.2f)\
+        message = "The first value of the minimum (%.2f)\
                  \nmust be less than the last value of the\
-                 \nminimum (%.2f)"
-            % (minfirst, minlast)
-        )
+                 \nminimum (%.2f)" % (minfirst, minlast)
         raise ControlValueError(message)
 
     # MAX-MAX: FIRST < LAST
     if maxfirst is not None and maxlast is not None and not maxfirst < maxlast:
-        message = (
-            "The first value of the maximum (%.2f)\
+        message = "The first value of the maximum (%.2f)\
                  \nmust be less than the last value of the\
-                 \nmaximum (%.2f)"
-            % (maxfirst, maxlast)
-        )
+                 \nmaximum (%.2f)" % (maxfirst, maxlast)
         raise ControlValueError(message)
 
     # MAX > MIN: FIRST-FIRST
     if maxfirst is not None and minfirst is not None and not maxfirst > minfirst:
-        message = (
-            "The first value of the fit maximum (%.2f)\
+        message = "The first value of the fit maximum (%.2f)\
                  \nmust be greater than first value of the fit\
-                 \nminimum (%.2f)."
-            % (maxfirst, minfirst)
-        )
+                 \nminimum (%.2f)." % (maxfirst, minfirst)
         raise ControlValueError(message)
 
     # MAX > MIN: LAST-LAST
     if maxlast is not None and minlast is not None and not maxlast > minlast:
-        message = (
-            "The last value of the fit maximum (%.2f)\
+        message = "The last value of the fit maximum (%.2f)\
                  \nmust be greater than last value of the fit\
-                 \nminimum (%.2f)."
-            % (maxlast, minlast)
-        )
+                 \nminimum (%.2f)." % (maxlast, minlast)
         raise ControlValueError(message)
 
     # STEP > 0
@@ -150,28 +138,19 @@ def makeRSeries(
 
             # Check to see that the values are in bounds and sensical
             if fitrmin < ds.rmin or fitrmin >= ds.rmax:
-                message = (
-                    "Fit minimum (%.2f) is outside the data range\
+                message = "Fit minimum (%.2f) is outside the data range\
                            \n[%.2f, %.2f].\
-                           \nAdjust the range of the series."
-                    % (fitrmin, ds.rmin, ds.rmax)
-                )
+                           \nAdjust the range of the series." % (fitrmin, ds.rmin, ds.rmax)
                 raise ControlValueError(message)
             if fitrmax <= ds.rmin or fitrmax > ds.rmax:
-                message = (
-                    "Fit maximum (%.2f) is outside the data range\
+                message = "Fit maximum (%.2f) is outside the data range\
                            \n[%.2f, %.2f].\
-                           \nAdjust the range of the series."
-                    % (fitrmax, ds.rmin, ds.rmax)
-                )
+                           \nAdjust the range of the series." % (fitrmax, ds.rmin, ds.rmax)
                 raise ControlValueError(message)
             if fitrmin >= fitrmax:
-                message = (
-                    "Fit minimum (%.2f) is greater than the\
+                message = "Fit minimum (%.2f) is greater than the\
                            \nmaximum (%.2f).\
-                           \nIncrease maxstep or reduce minstep."
-                    % (fitrmin, fitrmax)
-                )
+                           \nIncrease maxstep or reduce minstep." % (fitrmin, fitrmax)
                 raise ControlValueError(message)
 
             # Set the values if all is well
@@ -205,7 +184,6 @@ def makeTemperatureSeries(control, fit, paths, temperatures):
 
     returns a list of the new fit organization objects
     """
-
     if len(fit.datasets) != 1:
         message = "Can't apply macro to fits with multiple datasets."
         raise ControlValueError(message)

--- a/src/diffpy/pdfgui/control/pdfstructure.py
+++ b/src/diffpy/pdfgui/control/pdfstructure.py
@@ -58,11 +58,12 @@ class PDFStructure(PDFComponent, PDFFitStructure):
         return p
 
     def copy(self, other=None):
-        """Copy self to other. if other is None, create an instance.
+        """Copy self to other.
 
-        other -- ref to other object
+        if other is None, create an instance.
+                other -- ref to other object
 
-        returns reference to copied object
+                returns reference to copied object
         """
         if other is None:
             other = PDFStructure(self.name)

--- a/src/diffpy/pdfgui/control/structureviewer.py
+++ b/src/diffpy/pdfgui/control/structureviewer.py
@@ -37,8 +37,9 @@ _struviewer = None
 
 
 class StructureViewer(object):
-    """Class for plotting structure in general structure viewer. It
-    takes care of creating temporary structure file in a desired format
+    """Class for plotting structure in general structure viewer.
+
+    It takes care of creating temporary structure file in a desired format
     and launching structure viewer as a background process. The
     temporary files are removed when StructureViewer instance goes out
     of scope.
@@ -61,8 +62,9 @@ class StructureViewer(object):
     """
 
     def __init__(self, executable=None, argstr=None, fileformat=None):
-        """Create StructureViewer instance.  All arguments are optional,
-        they override defaults described in class docstring.  The
+        """Create StructureViewer instance.
+
+        All arguments are optional, they override defaults described in class docstring.  The
         configuration can be changed later using setConfig method.
 
         executable -- path to the structure viewer executable

--- a/src/diffpy/pdfgui/gui/debugoptions.py
+++ b/src/diffpy/pdfgui/gui/debugoptions.py
@@ -18,10 +18,13 @@ There should be exactly one instance of DebugOptions in pdfguiglobals
 module.
 """
 
+# FIXME: remove this line when `docformatter` fixes the blank line bug
+
 
 class DebugOptions:
-    """DebugOptions is a place to store various debugging options. There
-    should be just one instance defined in pdfguiglobals module. It
+    """DebugOptions is a place to store various debugging options.
+
+    There should be just one instance defined in pdfguiglobals module. It
     would be nice to have a simple way of setting them on command line.
 
     Options in short and long forms:
@@ -59,8 +62,9 @@ class DebugOptions:
         return
 
     def __getattr__(self, name):
-        """Resolve values of short options. This is called only when
-        normal lookup fails.
+        """Resolve values of short options.
+
+        This is called only when normal lookup fails.
 
         returns value of short debug option
         """

--- a/src/diffpy/pdfgui/gui/errorreportdialog.py
+++ b/src/diffpy/pdfgui/gui/errorreportdialog.py
@@ -39,27 +39,19 @@ You can view current bug reports and feature requests at
 Discuss PDFgui and learn about new developments and features at
 <a href="{mlist}">{mlist}</a>.
 </p>
-""".format(
-    issues=ISSUESTRACKER, mlist=USERSMAILINGLIST
-)
+""".format(issues=ISSUESTRACKER, mlist=USERSMAILINGLIST)
 
-_MSG_FEATURE_REQUEST = (
-    """
+_MSG_FEATURE_REQUEST = """
 <p>
 Share you thoughts about PDFgui!
 </p>
-"""
-    + _MSG_TRAILER
-)
+""" + _MSG_TRAILER
 
-_MSG_ERROR_REPORT = (
-    """
+_MSG_ERROR_REPORT = """
 <p>
 PDFgui has encountered a problem.  We are sorry for the inconvenience.
 </p><p>
-"""
-    + _MSG_TRAILER
-)
+""" + _MSG_TRAILER
 
 # ----------------------------------------------------------------------------
 

--- a/src/diffpy/pdfgui/gui/fittree.py
+++ b/src/diffpy/pdfgui/gui/fittree.py
@@ -124,10 +124,10 @@ class FitTree(wx.TreeCtrl):
         """Get the ids of the children of a given node."""
         cookie = 0
         ids = []
-        (child, cookie) = self.GetFirstChild(node)
+        child, cookie = self.GetFirstChild(node)
         while child.IsOk():
             ids.append(child)
-            (child, cookie) = self.GetNextChild(node, cookie)
+            child, cookie = self.GetNextChild(node, cookie)
 
         return ids
 

--- a/src/diffpy/pdfgui/gui/mainframe.py
+++ b/src/diffpy/pdfgui/gui/mainframe.py
@@ -49,7 +49,7 @@ from diffpy.pdfgui.gui.rseriespanel import RSeriesPanel
 from diffpy.pdfgui.gui.temperatureseriespanel import TemperatureSeriesPanel
 from diffpy.pdfgui.gui.welcomepanel import WelcomePanel
 
-(PDFCustomEvent, EVT_PDFCUSTOM) = wx.lib.newevent.NewEvent()
+PDFCustomEvent, EVT_PDFCUSTOM = wx.lib.newevent.NewEvent()
 
 # WARNING - This file cannot be maintained with wxglade any longer. Do not make
 # modifications with wxglade!!!
@@ -977,7 +977,6 @@ class MainFrame(wx.Frame):
         The MRU list is handled by the local member fileHistory, which
         is a wxFileHistory object.
         """
-
         # Get MRU information
         localpath = os.path.expanduser(pdfguiglobals.configfilename)
         if os.path.exists(localpath):
@@ -1363,9 +1362,9 @@ class MainFrame(wx.Frame):
         # not docked. This is a bit of a hack, since pane.floating_pos is not
         # designed to be a public attribute.
         pane = self.auiManager.GetPane("treeCtrlMain")
-        (x0, y0) = self.treeCtrlMain.GetPosition()
+        x0, y0 = self.treeCtrlMain.GetPosition()
         if pane.IsFloating():
-            (x0, y0) = self.ScreenToClient(pane.floating_pos)
+            x0, y0 = self.ScreenToClient(pane.floating_pos)
         self.PopupMenu(menu, (x0 + x, y0 + y))
         menu.Destroy()
         return
@@ -1599,7 +1598,6 @@ class MainFrame(wx.Frame):
 
     def disableMainMenuItems(self):
         """Disable main menu items."""
-
         menu = self.menuBar
         # First disable the shared items
 

--- a/src/diffpy/pdfgui/gui/parameterspanel.py
+++ b/src/diffpy/pdfgui/gui/parameterspanel.py
@@ -298,7 +298,6 @@ class ParametersPanel(wx.Panel, PDFPanel):
     # Popup menu events  ##################################################
     def onPopupFill(self, event):
         """Fills cells selected in the grid with a new value."""
-
         # NOTE: GetSelectedCells returns only SINGLE selected cells, not blocks or row/columns !
         if self.grid_parameters.IsSelection():
             dlg = wx.TextEntryDialog(self, "New value:", "Fill Selected Cells", "")
@@ -364,7 +363,6 @@ class ParametersPanel(wx.Panel, PDFPanel):
 
     def onPopupRenameParameters(self, event):
         """Rename parameters."""
-
         if self.grid_parameters.IsSelection():
             dlg = wx.TextEntryDialog(self, "New index:", "Rename Selected Parameters", "")
 

--- a/src/diffpy/pdfgui/gui/phaseconfigurepanel.py
+++ b/src/diffpy/pdfgui/gui/phaseconfigurepanel.py
@@ -318,7 +318,6 @@ class PhaseConfigurePanel(wx.Panel, PDFPanel):
     def restrictConstrainedParameters(self):
         """Set 'read-only' boxes that correspond to constrained
         parameters."""
-
         self.setToolTips(tooltips.phasepanel)
         self.textCtrlA.DefaultStyle.BackgroundColour
         txtbg = self.textCtrlScaleFactor.DefaultStyle.BackgroundColour

--- a/src/diffpy/pdfgui/gui/phaseconstraintspanel.py
+++ b/src/diffpy/pdfgui/gui/phaseconstraintspanel.py
@@ -278,7 +278,7 @@ class PhaseConstraintsPanel(wx.Panel, PDFPanel):
         # We need to call attr.IncRef before each SetX(attr)
         # https://github.com/wxWidgets/Phoenix/issues/627#issuecomment-354219493
 
-        # set 'elem' abd 'name' columns to read-only
+        # set 'elem' and 'name' columns to read-only
         attr = wx.grid.GridCellAttr()
         attr.SetReadOnly(True)
         attr.IncRef()
@@ -361,7 +361,6 @@ class PhaseConstraintsPanel(wx.Panel, PDFPanel):
 
     def refreshTextCtrls(self):
         """Refreshes the TextCtrls."""
-
         for widget, var in zip(self._textctrls, self.lConstraints):
             wobj = getattr(self, widget)
             if var in self.constraints:

--- a/src/diffpy/pdfgui/gui/preferencespanel.py
+++ b/src/diffpy/pdfgui/gui/preferencespanel.py
@@ -112,7 +112,6 @@ class PreferencesPanel(wx.Panel, PDFPanel):
 
     def __customProperties(self):
         """Set the custom properties."""
-
         # Fill the options in the format choice
         viewer = structureviewer.getStructureViewer()
         formats = viewer.getFileFormats()
@@ -140,7 +139,6 @@ class PreferencesPanel(wx.Panel, PDFPanel):
 
     def onOK(self, event):  # wxGlade: PreferencesPanel.<event_handler>
         """Record all of the preferences and return to fitting mode."""
-
         # Record structure viewer stuff
         executable = str(self.textCtrlViewer.GetValue()).strip()
         argstr = str(self.textCtrlArgument.GetValue()).strip()
@@ -172,7 +170,6 @@ class PreferencesPanel(wx.Panel, PDFPanel):
 
     def refresh(self):
         """Refresh the panel."""
-
         # Structure viewer stuff
         viewer = structureviewer.getStructureViewer()
         config = viewer.getConfig()

--- a/src/diffpy/pdfgui/gui/temperatureseriespanel.py
+++ b/src/diffpy/pdfgui/gui/temperatureseriespanel.py
@@ -227,12 +227,9 @@ class TemperatureSeriesPanel(wx.Panel, PDFPanel):
             # Some filenames fool this, e.g. "test1.dat" will match '1' since it
             # is preceded by a 't'.
             # Is there a better regexp? Probably...
-            regexp = (
-                r"""(?:[Tt](?:emp(?:erature)?)?(%(f)s))|
+            regexp = r"""(?:[Tt](?:emp(?:erature)?)?(%(f)s))|
                          (?:(?<![a-zA-Z0-9])(%(f)s)[Kk])
-                """
-                % rx
-            )
+                """ % rx
             res = re.search(regexp, os.path.basename(path), re.VERBOSE)
             if res:
                 groups = res.groups()

--- a/src/diffpy/pdfgui/gui/tooltips.py
+++ b/src/diffpy/pdfgui/gui/tooltips.py
@@ -14,6 +14,8 @@
 ##############################################################################
 """Tooltips for pdfgui panels."""
 
+# FIXME: remove this line when `docformatter` fixes the blank line bug
+
 
 def isalias(s):
     return s[1:-1] and s[:: len(s) - 1] == "{}" and s[1:-1].replace("_", "").isalnum()
@@ -140,7 +142,10 @@ all-all, -!Na        same as previous
 Na-1:4               pairs of Na and first 4 atoms
 all-all, !Cl-!Cl     exclude any pairs containing Cl
 all-all, !Cl-, -!Cl  same as previous
-1-all                only pairs including the first atom""",  # TextCtrl "all-all"
+1-all                only pairs including the first atom"""
+
+                                                           ,
+        # TextCtrl "all-all"
         #    'gridAtoms' : '', # AutoWidthLabelsGrid
     }
 )
@@ -168,12 +173,17 @@ preferencespanel = {
         "default to the current path."
     ),
     "textCtrlViewer": ("The name of the structure viewer executable, " "e.g., 'atomeye' or 'pymol'."),
-    "textCtrlArgument": """\
-The command-line arguments to the structure viewer.
-'%s' represents the file name that will be passed to the viewer.
-Command-line switches placed here will be passed as well.
-E. g. '%s' or '-c %s' (for pymol).\
-        """,
+    "textCtrlArgument":\
+                        """The command-line arguments to the structure
+                        viewer.
+
+                        '%s' represents the file name that will be
+                        passed to the viewer. Command-line switches
+                        placed here will be passed as well. E. g. '%s'
+                        or '-c %s' (for pymol).
+                        """
+
+                           ,
     "choiceFormat": "Choose a file format the structure viewer accepts.",
 }
 

--- a/src/diffpy/pdfgui/gui/wxextensions/autowidthlabelsgrid.py
+++ b/src/diffpy/pdfgui/gui/wxextensions/autowidthlabelsgrid.py
@@ -15,7 +15,6 @@
 """This module contains AutoWidthListCtrl, a wxListCtrl object that
 automatically adjusts the width of its columns."""
 
-
 import wx
 import wx.grid
 
@@ -47,8 +46,8 @@ class AutoWidthLabelsGrid(wx.grid.Grid):
             maxHeight = 0
             curCol = self.GetNumberCols() - 1
             while curCol >= 0:
-                (w, h, d, l) = devContext.GetFullTextExtent(self.GetColLabelValue(curCol))
-                curHeight = h + d + l + 4
+                width, height, descent, leading = devContext.GetFullTextExtent(self.GetColLabelValue(curCol))
+                curHeight = height + descent + leading + 4
                 if curHeight > maxHeight:
                     maxHeight = curHeight
                 curCol = curCol - 1

--- a/src/diffpy/pdfgui/gui/wxextensions/listctrls.py
+++ b/src/diffpy/pdfgui/gui/wxextensions/listctrls.py
@@ -21,7 +21,6 @@ KeyEventsListCtrl  - A ColumnSortListCtrl that selects and item as you type its
 name.
 """
 
-
 import wx
 import wx.lib.mixins.listctrl as listmix
 

--- a/src/diffpy/pdfgui/gui/wxextensions/paneldialog.py
+++ b/src/diffpy/pdfgui/gui/wxextensions/paneldialog.py
@@ -17,7 +17,6 @@
 """This module contains the PanelDialog class, a simple class that turns
 any panel into a dialog."""
 
-
 import wx
 
 

--- a/src/diffpy/pdfgui/gui/wxextensions/textctrlutils.py
+++ b/src/diffpy/pdfgui/gui/wxextensions/textctrlutils.py
@@ -16,7 +16,6 @@
 ##############################################################################
 """This module contains utilities that can be used with wxTextCtrls."""
 
-
 import wx
 
 

--- a/src/diffpy/pdfgui/tui.py
+++ b/src/diffpy/pdfgui/tui.py
@@ -12,8 +12,9 @@
 # See LICENSE.txt for license information.
 #
 ##############################################################################
-"""Text user interface - utilities for extracting data from project files.
-"""
+"""Text user interface - utilities for extracting data from project files."""
+
+# FIXME: remove this line when `docformatter` fixes the blank line bug
 
 
 class LoadProject:

--- a/src/diffpy/pdfgui/utils.py
+++ b/src/diffpy/pdfgui/utils.py
@@ -13,9 +13,11 @@
 #
 ##############################################################################
 """Small shared routines:
-    numericStringSort   -- sort list of strings according to numeric value
-    safeCPickleDumps    -- same as pickle.dumps, but safe for NaN and Inf
+numericStringSort   -- sort list of strings according to numeric value
+safeCPickleDumps    -- same as pickle.dumps, but safe for NaN and Inf
 """
+
+# FIXME: remove this line when `docformatter` fixes the blank line bug
 
 
 def numericStringSort(lst):
@@ -47,7 +49,6 @@ def safeCPickleDumps(obj):
 
     Return pickle string.
     """
-
     import pickle
 
     ascii_protocol = 0

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Unit tests for calculation.py."""
 
-
 import unittest
 
 from diffpy.pdfgui.control.calculation import Calculation

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Unit tests for constraint.py."""
 
-
 import unittest
 
 from diffpy.pdfgui.control.constraint import Constraint

--- a/tests/test_fitdataset.py
+++ b/tests/test_fitdataset.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Unit tests for fitdataset.py."""
 
-
 import unittest
 
 import numpy

--- a/tests/test_fitstructure.py
+++ b/tests/test_fitstructure.py
@@ -2,7 +2,6 @@
 
 """Unit tests for class FitStructure."""
 
-
 import unittest
 
 from testutils import datafile

--- a/tests/test_loadproject.py
+++ b/tests/test_loadproject.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Unit tests for tui.py."""
 
-
 import unittest
 
 from testutils import GUITestCase, datafile

--- a/tests/test_pdfdataset.py
+++ b/tests/test_pdfdataset.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Unit tests for pdfdataset.py."""
 
-
 import unittest
 
 from testutils import datafile

--- a/tests/test_pdfguicontrol.py
+++ b/tests/test_pdfguicontrol.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Unit tests for pdfgui.control.pdfguicontrol.py."""
 
-
 import unittest
 
 from diffpy.pdfgui.control.pdfguicontrol import PDFGuiControl

--- a/tests/test_pdfstructure.py
+++ b/tests/test_pdfstructure.py
@@ -2,7 +2,6 @@
 
 """Unit tests for class PDFStructure."""
 
-
 import unittest
 
 from testutils import datafile

--- a/tests/test_showphasenotebookpanel.py
+++ b/tests/test_showphasenotebookpanel.py
@@ -14,7 +14,6 @@
 ##############################################################################
 """Display the PhaseNotebookPanel."""
 
-
 import wx
 from testutils import datafile
 

--- a/tests/test_structureviewer.py
+++ b/tests/test_structureviewer.py
@@ -2,7 +2,6 @@
 
 """Unit tests for diffpy.pdfgui.control.structureviewer."""
 
-
 import os
 import unittest
 


### PR DESCRIPTION
Updated the pre-commit hook versions according to the recent Slack discussion and applied the resulting formatting/linting changes.

One remaining issue is a formatting conflict between `black` and `docformatter` affecting the following files:

- `src/diffpy/pdfgui/gui/tooltips.py`
- `src/diffpy/pdfgui/control/fitdataset.py`
- `src/diffpy/pdfgui/control/fitstructure.py`

In each case, the conflict is the same: `black` and `docformatter` repeatedly move the comma following a multiline triple-quoted string, preventing `pre-commit` from passing.